### PR TITLE
swap EBML-MINVER and MAXVER-COHERENCY samples

### DIFF
--- a/matroska/24.md
+++ b/matroska/24.md
@@ -10,10 +10,6 @@ Verify that the Elements used are defined with a minumum version value that is l
 
 ## Reproducibility
 ```
-ffmpeg -f lavfi -i testsrc2=s=120x80 -f lavfi -i sine -c:a flac -ar 8000 -vframes 2 -c:v ffv1 -level 3 -c:a flac -g 1 -y reference.mkv
-mkv2xml < reference.mkv > reference.xml
-xmlstarlet ed -L --update "/mkv2xml/EBML/DocTypeVersion" --value 4 reference.xml
-xmlstarlet ed -L --update "/mkv2xml/EBML/DocTypeReadVersion" --value 4 reference.xml
-xmlstarlet ed -L --subnode /mkv2xml/Segment/Tracks/TrackEntry -type elem -n TrackTimecodeScale -v 1.0000 reference.xml
-xml2mkv < reference.xml > EBML-MINVER-COHERANT.mkv
+ffmpeg -f lavfi -i testsrc2=s=120x80 -f lavfi -i sine -c:a flac -ar 8000 -vframes 2 -c:v ffv1 -level 3 -color_primaries smpte170m -c:a flac -g 1 -y EBML-MINVER-COHERANT.mkv
+sfk replace EBML-MINVER-COHERANT.mkv -bin '/4287810442858102/4287810342858103/' -yes
 ```

--- a/matroska/25.md
+++ b/matroska/25.md
@@ -10,6 +10,10 @@ Verify that the Elements used are not deprecated in the Matroska document versio
 
 ## Reproducibility
 ```
-ffmpeg -f lavfi -i testsrc2=s=120x80 -f lavfi -i sine -c:a flac -ar 8000 -vframes 2 -c:v ffv1 -level 3 -color_primaries smpte170m -c:a flac -g 1 -y EBML-MAXVER-COHERANT.mkv
-sfk replace EBML-MAXVER-COHERANT.mkv -bin '/4287810442858102/4287810342858103/' -yes
+ffmpeg -f lavfi -i testsrc2=s=120x80 -f lavfi -i sine -c:a flac -ar 8000 -vframes 2 -c:v ffv1 -level 3 -c:a flac -g 1 -y reference.mkv
+mkv2xml < reference.mkv > reference.xml
+xmlstarlet ed -L --update "/mkv2xml/EBML/DocTypeVersion" --value 4 reference.xml
+xmlstarlet ed -L --update "/mkv2xml/EBML/DocTypeReadVersion" --value 4 reference.xml
+xmlstarlet ed -L --subnode /mkv2xml/Segment/Tracks/TrackEntry -type elem -n TrackTimecodeScale -v 1.0000 reference.xml
+xml2mkv < reference.xml > EBML-MAXVER-COHERANT.mkv
 ```


### PR DESCRIPTION
The reproducibility notes were accidentally swapped.