### PR TITLE
Typos

### DIFF
--- a/matroska/24.md
+++ b/matroska/24.md
@@ -9,7 +9,7 @@ EBML elements used correlate to DocVersion.
 Verify that the Elements used are defined with a minumum version value that is less than or equal to the Matroska document version.
 
 ## Reproducibility
-```
+```sh
 ffmpeg -f lavfi -i testsrc2=s=120x80 -f lavfi -i sine -c:a flac -ar 8000 -vframes 2 -c:v ffv1 -level 3 -color_primaries smpte170m -c:a flac -g 1 -y EBML-MINVER-COHERANT.mkv
 sfk replace EBML-MINVER-COHERANT.mkv -bin '/4287810442858102/4287810342858103/' -yes
 ```

--- a/matroska/25.md
+++ b/matroska/25.md
@@ -9,7 +9,7 @@ EBML elements used correlate to DocVersion.
 Verify that the Elements used are not deprecated in the Matroska document version.
 
 ## Reproducibility
-```
+```sh
 ffmpeg -f lavfi -i testsrc2=s=120x80 -f lavfi -i sine -c:a flac -ar 8000 -vframes 2 -c:v ffv1 -level 3 -c:a flac -g 1 -y reference.mkv
 mkv2xml < reference.mkv > reference.xml
 xmlstarlet ed -L --update "/mkv2xml/EBML/DocTypeVersion" --value 4 reference.xml


### PR DESCRIPTION
Missing "sh" code format preventing automatic tests during continuous integration.